### PR TITLE
Make model available on SearchResults objects

### DIFF
--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -281,6 +281,10 @@ class BaseSearchResults:
         self._results_cache = None
         self._count_cache = None
         self._score_field = None
+        # Attach the model to mimic a QuerySet so that we can inspect it after
+        # doing a search, e.g. to get the model's name in a paginator.
+        # The query_compiler may be None, e.g. when using EmptySearchResults.
+        self.model = query_compiler.queryset.model if query_compiler else None
 
     def _set_limits(self, start=None, stop=None):
         if stop is not None:

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -81,6 +81,7 @@ class BackendTests:
             [r.title for r in results],
             ["JavaScript: The good parts", "JavaScript: The Definitive Guide"],
         )
+        self.assertEqual(results.model, models.Book)
 
     def test_search_count(self):
         results = self.backend.search("JavaScript", models.Book)


### PR DESCRIPTION
Ported from https://github.com/wagtail/wagtail/commit/05fa6e7b1b9e833b5948084f22fda201237aa5a9.

Add a `model` attribute to SearchResults objects - this is consistent with Django QuerySet objects and is used by Wagtail to access verbose_name_plural to make listings more descriptive ("10 images" rather than "10 items").