### PR TITLE
Refactoring to accommodate Wagtail migration path

### DIFF
--- a/modelsearch/__init__.py
+++ b/modelsearch/__init__.py
@@ -1,3 +1,8 @@
+from functools import cache
+
+from django.core.exceptions import ImproperlyConfigured
+
+
 def format_version(version):
     if version[2] == 0:
         # Ignore patch if it's 0
@@ -14,3 +19,31 @@ def format_version(version):
 
 VERSION = (1, 0, 0, "final", 0)
 __version__ = format_version(VERSION)
+
+
+@cache
+def get_app_config():
+    """
+    Return the ModelSearchAppConfig instance registered in the Django app registry.
+    This allows for ModelSearchAppConfig to be subclassed and made available under a different
+    module path and/or app label, rather than hardcoding "modelsearch" - Wagtail makes use of this
+    to allow existing projects to continue using "wagtail.search" in INSTALLED_APPS.
+    """
+    from django.apps import apps
+
+    from modelsearch.apps import ModelSearchAppConfig
+
+    app_configs = [
+        app_config
+        for app_config in apps.get_app_configs()
+        if isinstance(app_config, ModelSearchAppConfig)
+    ]
+    if len(app_configs) == 0:  # pragma: no cover
+        raise ImproperlyConfigured(
+            "The modelsearch app was not found in INSTALLED_APPS"
+        )
+    elif len(app_configs) > 1:  # pragma: no cover
+        raise ImproperlyConfigured(
+            "Multiple instances of the modelsearch app were found in INSTALLED_APPS"
+        )
+    return app_configs[0]

--- a/modelsearch/abstract_models.py
+++ b/modelsearch/abstract_models.py
@@ -1,0 +1,162 @@
+from django.apps import apps
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection, models
+from django.db.models.fields import TextField
+from django.db.models.functions import Cast
+from django.db.models.sql.where import WhereNode
+from django.utils.translation import gettext_lazy as _
+
+from .index import class_is_indexed
+from .utils import get_descendants_content_types_pks
+
+
+class TextIDGenericRelation(GenericRelation):
+    auto_created = True
+
+    def get_content_type_lookup(self, alias, remote_alias):
+        field = self.remote_field.model._meta.get_field(self.content_type_field_name)
+        return field.get_lookup("in")(
+            field.get_col(remote_alias), get_descendants_content_types_pks(self.model)
+        )
+
+    def get_object_id_lookup(self, alias, remote_alias):
+        from_field = self.remote_field.model._meta.get_field(self.object_id_field_name)
+        to_field = self.model._meta.pk
+        return from_field.get_lookup("exact")(
+            from_field.get_col(remote_alias), Cast(to_field.get_col(alias), from_field)
+        )
+
+    def get_extra_restriction(self, alias, remote_alias):
+        cond = WhereNode()
+        cond.add(self.get_content_type_lookup(alias, remote_alias), "AND")
+        cond.add(self.get_object_id_lookup(alias, remote_alias), "AND")
+        return cond
+
+    def resolve_related_fields(self):
+        return []
+
+
+class BaseIndexEntry(models.Model):
+    """
+    This is an abstract class that only contains fields common to all database vendors.
+    It should be extended by the models specific for each backend.
+    """
+
+    content_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, related_name="+"
+    )
+    # We do not use an IntegerField since primary keys are not always integers.
+    object_id = models.CharField(max_length=50)
+    content_object = GenericForeignKey()
+
+    # TODO: Add per-object boosting.
+    # This field stores the "Title Normalisation Factor"
+    # This factor is multiplied onto the rank of the title field.
+    # This allows us to apply a boost to results with shorter titles
+    # elevating more specific matches to the top.
+    title_norm = models.FloatField(default=1.0)
+
+    wagtail_reference_index_ignore = True
+
+    class Meta:
+        unique_together = ("content_type", "object_id")
+        verbose_name = _("index entry")
+        verbose_name_plural = _("index entries")
+        abstract = True
+
+    def __str__(self):
+        return f"{self.content_type.name}: {self.content_object}"
+
+    @property
+    def model(self):
+        return self.content_type.model
+
+    @classmethod
+    def add_generic_relations(cls):
+        for model in apps.get_models():
+            if class_is_indexed(model):
+                TextIDGenericRelation(cls).contribute_to_class(model, "index_entries")
+
+
+AbstractSQLiteFTSIndexEntry = None
+
+
+# AbstractIndexEntry will be defined depending on which database system we're using.
+if connection.vendor == "postgresql":
+    from django.contrib.postgres.indexes import GinIndex
+    from django.contrib.postgres.search import SearchVectorField
+
+    class AbstractPostgresIndexEntry(BaseIndexEntry):
+        """
+        This class is the specific IndexEntry model for PostgreSQL database systems.
+        It inherits the fields defined in BaseIndexEntry, and adds PostgreSQL-specific
+        fields (tsvectors), plus indexes for doing full-text search on those fields.
+        """
+
+        # TODO: Add per-object boosting.
+        autocomplete = SearchVectorField()
+        title = SearchVectorField()
+        body = SearchVectorField()
+
+        class Meta(BaseIndexEntry.Meta):
+            abstract = True
+            # An additional computed GIN index on 'title || body' is created in a SQL migration
+            # covers the default case of PostgresSearchQueryCompiler.get_index_vectors.
+            indexes = [
+                GinIndex(fields=["autocomplete"]),
+                GinIndex(fields=["title"]),
+                GinIndex(fields=["body"]),
+            ]
+
+    AbstractIndexEntry = AbstractPostgresIndexEntry
+
+elif connection.vendor == "sqlite":
+    from modelsearch.backends.database.sqlite.utils import fts5_available
+
+    class AbstractSQLiteIndexEntry(BaseIndexEntry):
+        """
+        This class is the specific IndexEntry model for SQLite database systems. The autocomplete, title, and body fields store additional
+        """
+
+        autocomplete = TextField(null=True)  # NOQA: DJ001
+        title = TextField(null=False)
+        body = TextField(null=True)  # NOQA: DJ001
+
+        class Meta(BaseIndexEntry.Meta):
+            abstract = True
+
+    AbstractIndexEntry = AbstractSQLiteIndexEntry
+
+    if fts5_available():
+
+        class AbstractSQLiteFTSIndexEntry(models.Model):
+            autocomplete = TextField(null=True)  # NOQA: DJ001
+            title = TextField(null=False)
+            body = TextField(null=True)  # NOQA: DJ001
+            # Concrete subclasses will define a one-to-one relation to IndexEntry
+
+            class Meta:
+                abstract = True
+
+            def __str__(self):
+                return f"SQLiteFTSIndexEntry: {self.index_entry}"
+
+elif connection.vendor == "mysql":
+
+    class AbstractMySQLIndexEntry(BaseIndexEntry):
+        """
+        This class is the specific IndexEntry model for MySQL database systems.
+        """
+
+        autocomplete = TextField(null=True)  # NOQA: DJ001
+        title = TextField(null=False)
+        body = TextField(null=True)  # NOQA: DJ001
+
+        class Meta(BaseIndexEntry.Meta):
+            abstract = True
+
+    AbstractIndexEntry = AbstractMySQLIndexEntry
+
+else:
+    AbstractIndexEntry = BaseIndexEntry

--- a/modelsearch/apps.py
+++ b/modelsearch/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django.core.checks import Tags, Warning, register
 from django.db import connection
 
@@ -10,6 +11,7 @@ class ModelSearchAppConfig(AppConfig):
     label = "modelsearch"
     verbose_name = "Django ModelSearch"
     default_auto_field = "django.db.models.AutoField"
+    backend_setting_name = "MODELSEARCH_BACKENDS"
 
     def ready(self):
         register_signal_handlers()
@@ -23,6 +25,19 @@ class ModelSearchAppConfig(AppConfig):
         from modelsearch.models import IndexEntry
 
         IndexEntry.add_generic_relations()
+
+    def get_search_backend_config(self):
+        search_backends = getattr(settings, self.backend_setting_name, {})
+
+        # Make sure the default backend is always defined
+        search_backends.setdefault(
+            "default",
+            {
+                "BACKEND": "modelsearch.backends.database",
+            },
+        )
+
+        return search_backends
 
     @register(Tags.compatibility, Tags.database)
     def check_if_sqlite_version_is_supported(app_configs, **kwargs):

--- a/modelsearch/apps.py
+++ b/modelsearch/apps.py
@@ -22,9 +22,7 @@ class ModelSearchAppConfig(AppConfig):
 
             set_weights()
 
-        from modelsearch.models import IndexEntry
-
-        IndexEntry.add_generic_relations()
+        self.get_model("IndexEntry").add_generic_relations()
 
     def get_search_backend_config(self):
         search_backends = getattr(settings, self.backend_setting_name, {})

--- a/modelsearch/backends/__init__.py
+++ b/modelsearch/backends/__init__.py
@@ -8,23 +8,11 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
+from modelsearch import get_app_config
+
 
 class InvalidSearchBackendError(ImproperlyConfigured):
     pass
-
-
-def get_search_backend_config():
-    search_backends = getattr(settings, "MODELSEARCH_BACKENDS", {})
-
-    # Make sure the default backend is always defined
-    search_backends.setdefault(
-        "default",
-        {
-            "BACKEND": "modelsearch.backends.database",
-        },
-    )
-
-    return search_backends
 
 
 def import_backend(dotted_path):
@@ -61,7 +49,7 @@ def get_search_backend(backend="default", **kwargs):
     All options within the MODELSEARCH_BACKENDS entry (except for `BACKEND` itself) will be passed to the backend class during instantiation. Additional
     keyword arguments will also be passed to the backend class (and override options from MODELSEARCH_BACKENDS).
     """
-    search_backends = get_search_backend_config()
+    search_backends = get_app_config().get_search_backend_config()
 
     # Try to find the backend
     try:
@@ -109,7 +97,7 @@ def _backend_requires_auto_update(backend_name, params):
 
 
 def get_search_backends_with_name(with_auto_update=False):
-    search_backends = get_search_backend_config()
+    search_backends = get_app_config().get_search_backend_config()
     for backend, params in search_backends.items():
         if with_auto_update and _backend_requires_auto_update(backend, params) is False:
             continue

--- a/modelsearch/backends/database/mysql/mysql.py
+++ b/modelsearch/backends/database/mysql/mysql.py
@@ -20,6 +20,7 @@ from django.db.models.manager import Manager
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
+from modelsearch import get_app_config
 from modelsearch.backends.base import (
     BaseIndex,
     BaseSearchBackend,
@@ -38,13 +39,15 @@ from modelsearch.index import (
     SearchField,
     get_indexed_models,
 )
-from modelsearch.models import IndexEntry
 from modelsearch.query import And, Boost, MatchAll, Not, Or, Phrase, PlainText
 from modelsearch.utils import (
     balanced_reduce,
     get_content_type_pk,
     get_descendants_content_types_pks,
 )
+
+
+IndexEntry = get_app_config().get_model("IndexEntry", require_ready=False)
 
 
 class ObjectIndexer:

--- a/modelsearch/backends/database/postgres/postgres.py
+++ b/modelsearch/backends/database/postgres/postgres.py
@@ -17,8 +17,9 @@ from django.db.models.sql.subqueries import InsertQuery
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
+from modelsearch import get_app_config
+
 from ....index import AutocompleteField, RelatedFields, SearchField, get_indexed_models
-from ....models import IndexEntry
 from ....query import And, Boost, MatchAll, Not, Or, Phrase, PlainText
 from ....utils import (
     ADD,
@@ -37,6 +38,7 @@ from .query import Lexeme
 from .weights import get_sql_weights, get_weight
 
 
+IndexEntry = get_app_config().get_model("IndexEntry", require_ready=False)
 EMPTY_VECTOR = SearchVector(Value("", output_field=TextField()))
 
 

--- a/modelsearch/backends/database/sqlite/sqlite.py
+++ b/modelsearch/backends/database/sqlite/sqlite.py
@@ -13,8 +13,9 @@ from django.db.models.functions import Cast, Length
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
+from modelsearch import get_app_config
+
 from ....index import AutocompleteField, RelatedFields, SearchField, get_indexed_models
-from ....models import IndexEntry, SQLiteFTSIndexEntry
 from ....query import And, MatchAll, Not, Or, Phrase, PlainText
 from ....utils import (
     ADD,
@@ -37,6 +38,11 @@ from .query import (
     SearchQueryExpression,
     normalize,
 )
+
+
+app_config = get_app_config()
+IndexEntry = app_config.get_model("IndexEntry", require_ready=False)
+SQLiteFTSIndexEntry = app_config.get_model("SQLiteFTSIndexEntry", require_ready=False)
 
 
 class ObjectIndexer:

--- a/modelsearch/backends/database/sqlite/utils.py
+++ b/modelsearch/backends/database/sqlite/utils.py
@@ -23,7 +23,9 @@ def fts5_available():
 
 
 def fts_table_exists():
-    from modelsearch.models import SQLiteFTSIndexEntry
+    from modelsearch import get_app_config
+
+    SQLiteFTSIndexEntry = get_app_config().get_model("SQLiteFTSIndexEntry")
 
     try:
         # ignore result of query; we are only interested in the query failing,

--- a/modelsearch/management/commands/rebuild_modelsearch_index.py
+++ b/modelsearch/management/commands/rebuild_modelsearch_index.py
@@ -3,7 +3,8 @@ import collections
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from modelsearch.backends import get_search_backend, get_search_backend_config
+from modelsearch import get_app_config
+from modelsearch.backends import get_search_backend
 from modelsearch.index import get_indexed_models
 
 
@@ -145,7 +146,7 @@ class Command(BaseCommand):
             backend_names = [options["backend_name"]]
         else:
             # index all backends listed in the search backend config
-            backend_names = get_search_backend_config().keys()
+            backend_names = get_app_config().get_search_backend_config().keys()
 
         # Update backends
         for backend_name in backend_names:

--- a/modelsearch/management/commands/rebuild_modelsearch_index.py
+++ b/modelsearch/management/commands/rebuild_modelsearch_index.py
@@ -1,10 +1,9 @@
 import collections
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from modelsearch.backends import get_search_backend
+from modelsearch.backends import get_search_backend, get_search_backend_config
 from modelsearch.index import get_indexed_models
 
 
@@ -144,12 +143,9 @@ class Command(BaseCommand):
         if options["backend_name"]:
             # index only the passed backend
             backend_names = [options["backend_name"]]
-        elif hasattr(settings, "MODELSEARCH_BACKENDS"):
-            # index all backends listed in settings
-            backend_names = settings.MODELSEARCH_BACKENDS.keys()
         else:
-            # index the 'default' backend only
-            backend_names = ["default"]
+            # index all backends listed in the search backend config
+            backend_names = get_search_backend_config().keys()
 
         # Update backends
         for backend_name in backend_names:

--- a/modelsearch/models.py
+++ b/modelsearch/models.py
@@ -1,168 +1,7 @@
-from django.apps import apps
-from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
-from django.contrib.contenttypes.models import ContentType
-from django.db import connection, models
-from django.db.models.fields import TextField
-from django.db.models.fields.related import OneToOneField
-from django.db.models.functions import Cast
-from django.db.models.sql.where import WhereNode
-from django.utils.translation import gettext_lazy as _
+from django.db import models
+from django.db.models import OneToOneField
 
-from .index import class_is_indexed
-from .utils import get_descendants_content_types_pks
-
-
-class TextIDGenericRelation(GenericRelation):
-    auto_created = True
-
-    def get_content_type_lookup(self, alias, remote_alias):
-        field = self.remote_field.model._meta.get_field(self.content_type_field_name)
-        return field.get_lookup("in")(
-            field.get_col(remote_alias), get_descendants_content_types_pks(self.model)
-        )
-
-    def get_object_id_lookup(self, alias, remote_alias):
-        from_field = self.remote_field.model._meta.get_field(self.object_id_field_name)
-        to_field = self.model._meta.pk
-        return from_field.get_lookup("exact")(
-            from_field.get_col(remote_alias), Cast(to_field.get_col(alias), from_field)
-        )
-
-    def get_extra_restriction(self, alias, remote_alias):
-        cond = WhereNode()
-        cond.add(self.get_content_type_lookup(alias, remote_alias), "AND")
-        cond.add(self.get_object_id_lookup(alias, remote_alias), "AND")
-        return cond
-
-    def resolve_related_fields(self):
-        return []
-
-
-class BaseIndexEntry(models.Model):
-    """
-    This is an abstract class that only contains fields common to all database vendors.
-    It should be extended by the models specific for each backend.
-    """
-
-    content_type = models.ForeignKey(
-        ContentType, on_delete=models.CASCADE, related_name="+"
-    )
-    # We do not use an IntegerField since primary keys are not always integers.
-    object_id = models.CharField(max_length=50)
-    content_object = GenericForeignKey()
-
-    # TODO: Add per-object boosting.
-    # This field stores the "Title Normalisation Factor"
-    # This factor is multiplied onto the rank of the title field.
-    # This allows us to apply a boost to results with shorter titles
-    # elevating more specific matches to the top.
-    title_norm = models.FloatField(default=1.0)
-
-    wagtail_reference_index_ignore = True
-
-    class Meta:
-        unique_together = ("content_type", "object_id")
-        verbose_name = _("index entry")
-        verbose_name_plural = _("index entries")
-        abstract = True
-
-    def __str__(self):
-        return f"{self.content_type.name}: {self.content_object}"
-
-    @property
-    def model(self):
-        return self.content_type.model
-
-    @classmethod
-    def add_generic_relations(cls):
-        for model in apps.get_models():
-            if class_is_indexed(model):
-                TextIDGenericRelation(cls).contribute_to_class(model, "index_entries")
-
-
-# AbstractIndexEntry will be defined depending on which database system we're using.
-if connection.vendor == "postgresql":
-    from django.contrib.postgres.indexes import GinIndex
-    from django.contrib.postgres.search import SearchVectorField
-
-    class AbstractPostgresIndexEntry(BaseIndexEntry):
-        """
-        This class is the specific IndexEntry model for PostgreSQL database systems.
-        It inherits the fields defined in BaseIndexEntry, and adds PostgreSQL-specific
-        fields (tsvectors), plus indexes for doing full-text search on those fields.
-        """
-
-        # TODO: Add per-object boosting.
-        autocomplete = SearchVectorField()
-        title = SearchVectorField()
-        body = SearchVectorField()
-
-        class Meta(BaseIndexEntry.Meta):
-            abstract = True
-            # An additional computed GIN index on 'title || body' is created in a SQL migration
-            # covers the default case of PostgresSearchQueryCompiler.get_index_vectors.
-            indexes = [
-                GinIndex(fields=["autocomplete"]),
-                GinIndex(fields=["title"]),
-                GinIndex(fields=["body"]),
-            ]
-
-    AbstractIndexEntry = AbstractPostgresIndexEntry
-
-elif connection.vendor == "sqlite":
-    from modelsearch.backends.database.sqlite.utils import fts5_available
-
-    class AbstractSQLiteIndexEntry(BaseIndexEntry):
-        """
-        This class is the specific IndexEntry model for SQLite database systems. The autocomplete, title, and body fields store additional
-        """
-
-        autocomplete = TextField(null=True)  # NOQA: DJ001
-        title = TextField(null=False)
-        body = TextField(null=True)  # NOQA: DJ001
-
-        class Meta(BaseIndexEntry.Meta):
-            abstract = True
-
-    AbstractIndexEntry = AbstractSQLiteIndexEntry
-
-    if fts5_available():
-
-        class SQLiteFTSIndexEntry(models.Model):
-            autocomplete = TextField(null=True)  # NOQA: DJ001
-            title = TextField(null=False)
-            body = TextField(null=True)  # NOQA: DJ001
-            index_entry = OneToOneField(
-                primary_key=True,
-                to="modelsearch.indexentry",
-                on_delete=models.CASCADE,
-                db_column="rowid",
-            )
-
-            class Meta:
-                db_table = "modelsearch_indexentry_fts"
-
-            def __str__(self):
-                return f"SQLiteFTSIndexEntry: {self.index_entry}"
-
-elif connection.vendor == "mysql":
-
-    class AbstractMySQLIndexEntry(BaseIndexEntry):
-        """
-        This class is the specific IndexEntry model for MySQL database systems.
-        """
-
-        autocomplete = TextField(null=True)  # NOQA: DJ001
-        title = TextField(null=False)
-        body = TextField(null=True)  # NOQA: DJ001
-
-        class Meta(BaseIndexEntry.Meta):
-            abstract = True
-
-    AbstractIndexEntry = AbstractMySQLIndexEntry
-
-else:
-    AbstractIndexEntry = BaseIndexEntry
+from .abstract_models import AbstractIndexEntry, AbstractSQLiteFTSIndexEntry
 
 
 class IndexEntry(AbstractIndexEntry):
@@ -176,3 +15,26 @@ class IndexEntry(AbstractIndexEntry):
         """
 
         abstract = False
+
+
+if AbstractSQLiteFTSIndexEntry:
+
+    class SQLiteFTSIndexEntry(AbstractSQLiteFTSIndexEntry):
+        """
+        The SQLite FTS IndexEntry model that will get created in the database if using SQLite with FTS5 support.
+        """
+
+        index_entry = OneToOneField(
+            primary_key=True,
+            to=IndexEntry,
+            on_delete=models.CASCADE,
+            db_column="rowid",
+        )
+
+        class Meta(AbstractSQLiteFTSIndexEntry.Meta):
+            """
+            Contains everything in the AbstractSQLiteFTSIndexEntry Meta class, but makes this model concrete.
+            """
+
+            abstract = False
+            db_table = "modelsearch_indexentry_fts"

--- a/modelsearch/test/settings.py
+++ b/modelsearch/test/settings.py
@@ -25,7 +25,6 @@ ALLOWED_HOSTS = ["localhost", "testserver"]
 INSTALLED_APPS = [
     "modelsearch.test.testapp",
     "modelsearch",
-    "modelcluster",
     "taggit",
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
Various bits of refactoring to allow Wagtail to switch to django-modelsearch for its search implementation while retaining `WAGTAILSEARCH_BACKENDS` as the setting name and keeping IndexEntry models in the `wagtailsearch` namespace. This should allow users to upgrade without having to change any settings in their projects.

(INDEX => INDEX_PREFIX and content_type => _django_content_type still to be accounted for...)

In this approach, we expect to find exactly one instance of ModelSearchAppConfig in the app registry, coming from either `modelsearch` or `wagtail.search` being present in INSTALLED_APPS. We then use this AppConfig instance as the source of truth when retrieving the backend config or importing model classes.

On the Wagtail side, we can then make things work as before as follows:

* In `wagtail.search.apps`, define `WagtailSearchAppConfig` as a subclass of `ModelSearchAppConfig` that overrides `name`, `label` and `backend_setting_name`
* In `wagtail.search.models`, import all abstract models from `modelsearch.abstract_models` and define concrete-ified versions of them, the same as `modelsearch.models` now does
* Make all other submodules of `wagtail.search` into stubs that simply import everything from their `modelsearch` counterparts
